### PR TITLE
Somnia Republish Strategy

### DIFF
--- a/src/main/java/io/ep2p/somnia/config/SomniaAutoConfiguration.java
+++ b/src/main/java/io/ep2p/somnia/config/SomniaAutoConfiguration.java
@@ -99,9 +99,7 @@ public class SomniaAutoConfiguration {
     @Bean("redistributionTaskHandler")
     @DependsOn({"somniaKademliaRepository"})
     public RedistributionTaskHandler redistributionTaskHandler(KademliaRepository<SomniaKey, SomniaValue> somniaKademliaRepository) {
-        DefaultRedistributionTaskHandler defaultRedistributionTaskHandler = new DefaultRedistributionTaskHandler();
-        defaultRedistributionTaskHandler.init(somniaKademliaRepository);
-        return defaultRedistributionTaskHandler;
+        return new DefaultRedistributionTaskHandler();
     }
 
     @Bean(value = "somniaNodeSettings")
@@ -132,7 +130,9 @@ public class SomniaAutoConfiguration {
             KademliaRepository<SomniaKey, SomniaValue> somniaKademliaRepository,
             SomniaEntityManager somniaEntityManager, SomniaStorageConfig somniaDecentralizedSomniaStorageConfig,
             RedistributionTaskHandler redistributionTaskHandler){
-        return new SomniaKademliaSyncRepositoryNode(somniaNodeId, routingTable, nodeConnectionApi, somniaConnectionInfo, somniaNodeSettings, somniaKademliaRepository, somniaEntityManager, somniaDecentralizedSomniaStorageConfig, redistributionTaskHandler);
+        SomniaKademliaSyncRepositoryNode somniaKademliaSyncRepositoryNode = new SomniaKademliaSyncRepositoryNode(somniaNodeId, routingTable, nodeConnectionApi, somniaConnectionInfo, somniaNodeSettings, somniaKademliaRepository, somniaEntityManager, somniaDecentralizedSomniaStorageConfig, redistributionTaskHandler);
+        redistributionTaskHandler.init(somniaKademliaSyncRepositoryNode);
+        return somniaKademliaSyncRepositoryNode;
     }
 
     @Bean("somniaHashGenerator")

--- a/src/main/java/io/ep2p/somnia/config/SomniaAutoConfiguration.java
+++ b/src/main/java/io/ep2p/somnia/config/SomniaAutoConfiguration.java
@@ -5,9 +5,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import io.ep2p.kademlia.NodeSettings;
+import io.ep2p.kademlia.connection.ConnectionInfo;
 import io.ep2p.kademlia.connection.NodeConnectionApi;
 import io.ep2p.kademlia.node.KademliaRepository;
 import io.ep2p.kademlia.node.external.ExternalNode;
+import io.ep2p.kademlia.service.RepublishStrategy;
+import io.ep2p.kademlia.service.RepublishStrategyFactory;
 import io.ep2p.kademlia.table.Bucket;
 import io.ep2p.kademlia.table.RoutingTable;
 import io.ep2p.somnia.config.properties.SomniaBaseConfigProperties;
@@ -18,10 +21,7 @@ import io.ep2p.somnia.config.serialization.ExternalNodeSerializer;
 import io.ep2p.somnia.decentralized.*;
 import io.ep2p.somnia.model.SomniaKey;
 import io.ep2p.somnia.model.SomniaValue;
-import io.ep2p.somnia.service.DefaultRedistributionTaskHandler;
-import io.ep2p.somnia.service.EntityManagerRegisterer;
-import io.ep2p.somnia.service.HashGenerator;
-import io.ep2p.somnia.service.RedistributionTaskHandler;
+import io.ep2p.somnia.service.*;
 import io.ep2p.somnia.storage.DefaultInMemoryStorage;
 import io.ep2p.somnia.storage.MongoStorage;
 import io.ep2p.somnia.storage.Storage;
@@ -106,6 +106,19 @@ public class SomniaAutoConfiguration {
     @DependsOn({"somniaKademliaRepository"})
     public RedistributionTaskHandler redistributionTaskHandler(KademliaRepository<SomniaKey, SomniaValue> somniaKademliaRepository) {
         return new DefaultRedistributionTaskHandler();
+    }
+
+    @Bean
+    public RepublishStrategy<BigInteger, SomniaConnectionInfo, SomniaKey, SomniaValue> republishStrategy(){
+        SomniaRepublishStrategy somniaRepublishStrategy = new SomniaRepublishStrategy();
+        RepublishStrategyFactory.PROVIDER = new RepublishStrategyFactory.Provider() {
+            @Override
+            @SuppressWarnings("unchecked")
+            public <ID extends Number, C extends ConnectionInfo, K, V> RepublishStrategy<ID, C, K, V> provide() {
+                return (RepublishStrategy<ID, C, K, V>) somniaRepublishStrategy;
+            }
+        };
+        return somniaRepublishStrategy;
     }
 
     @Bean(value = "somniaNodeSettings")

--- a/src/main/java/io/ep2p/somnia/config/SomniaAutoConfiguration.java
+++ b/src/main/java/io/ep2p/somnia/config/SomniaAutoConfiguration.java
@@ -15,6 +15,7 @@ import io.ep2p.kademlia.table.Bucket;
 import io.ep2p.kademlia.table.RoutingTable;
 import io.ep2p.somnia.config.properties.SomniaBaseConfigProperties;
 import io.ep2p.somnia.config.properties.SomniaDecentralizedConfigProperties;
+import io.ep2p.somnia.config.properties.SomniaKademliaRepublishSettingsProperties;
 import io.ep2p.somnia.config.properties.SomniaKademliaSettingsProperties;
 import io.ep2p.somnia.config.serialization.ExternalNodeDeserializer;
 import io.ep2p.somnia.config.serialization.ExternalNodeSerializer;
@@ -37,7 +38,7 @@ import org.springframework.data.mongodb.repository.config.EnableMongoRepositorie
 import java.math.BigInteger;
 
 @Configuration
-@EnableConfigurationProperties({SomniaBaseConfigProperties.class, SomniaDecentralizedConfigProperties.class, SomniaKademliaSettingsProperties.class})
+@EnableConfigurationProperties({SomniaBaseConfigProperties.class, SomniaDecentralizedConfigProperties.class, SomniaKademliaSettingsProperties.class, SomniaKademliaRepublishSettingsProperties.class})
 @EnableMongoRepositories
 public class SomniaAutoConfiguration {
 
@@ -122,7 +123,7 @@ public class SomniaAutoConfiguration {
     }
 
     @Bean(value = "somniaNodeSettings")
-    public NodeSettings somniaNodeSettings(SomniaKademliaSettingsProperties somniaKademliaSettingsProperties){
+    public NodeSettings somniaNodeSettings(SomniaKademliaSettingsProperties somniaKademliaSettingsProperties, SomniaKademliaRepublishSettingsProperties somniaKademliaRepublishSettingsProperties){
         return NodeSettings.builder()
                 .maximumLastSeenAgeToConsiderAlive(somniaKademliaSettingsProperties.getMaximumLastSeenAgeToConsiderAlive())
                 .findNodeSize(somniaKademliaSettingsProperties.getFindNodeSize())
@@ -133,7 +134,8 @@ public class SomniaAutoConfiguration {
                 .alpha(somniaKademliaSettingsProperties.getAlpha())
                 .storeTimeout(somniaKademliaSettingsProperties.getStoreTimeout())
                 .bootstrapNodeCallTimeout(somniaKademliaSettingsProperties.getBootstrapNodeCallTimeout())
-                .enabledRepublishing(false)
+                .enabledRepublishing(somniaKademliaSettingsProperties.isEnabledRepublishing())
+                .republishSettings(somniaKademliaRepublishSettingsProperties)
                 .build();
     }
 

--- a/src/main/java/io/ep2p/somnia/config/SomniaAutoConfiguration.java
+++ b/src/main/java/io/ep2p/somnia/config/SomniaAutoConfiguration.java
@@ -56,6 +56,7 @@ public class SomniaAutoConfiguration {
         ObjectMapper objectMapper = new ObjectMapper();
         objectMapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
         objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        objectMapper.configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true);
         objectMapper.registerModule(somniaSimpleModule);
         return objectMapper;
     }
@@ -68,11 +69,16 @@ public class SomniaAutoConfiguration {
                 .build();
     }
 
+    @Bean("somniaHashGenerator")
+    public HashGenerator hashGenerator(){
+        return new HashGenerator.DefaultHashGenerator();
+    }
+
     @Bean("mongoStorage")
     @ConditionalOnMissingBean(name = "mongoStorage")
-    @DependsOn({"mongoTemplate", "objectMapper"})
-    public Storage mongoStorage(MongoTemplate mongoTemplate, ObjectMapper objectMapper){
-        return new MongoStorage(mongoTemplate, objectMapper);
+    @DependsOn({"mongoTemplate", "objectMapper", "hashGenerator"})
+    public Storage mongoStorage(MongoTemplate mongoTemplate, ObjectMapper objectMapper, HashGenerator hashGenerator){
+        return new MongoStorage(mongoTemplate, objectMapper, hashGenerator);
     }
 
     @Bean("inMemoryStorage")
@@ -133,11 +139,6 @@ public class SomniaAutoConfiguration {
         SomniaKademliaSyncRepositoryNode somniaKademliaSyncRepositoryNode = new SomniaKademliaSyncRepositoryNode(somniaNodeId, routingTable, nodeConnectionApi, somniaConnectionInfo, somniaNodeSettings, somniaKademliaRepository, somniaEntityManager, somniaDecentralizedSomniaStorageConfig, redistributionTaskHandler);
         redistributionTaskHandler.init(somniaKademliaSyncRepositoryNode);
         return somniaKademliaSyncRepositoryNode;
-    }
-
-    @Bean("somniaHashGenerator")
-    public HashGenerator hashGenerator(){
-        return new HashGenerator.DefaultHashGenerator();
     }
 
     @Bean

--- a/src/main/java/io/ep2p/somnia/config/properties/SomniaBaseConfigProperties.java
+++ b/src/main/java/io/ep2p/somnia/config/properties/SomniaBaseConfigProperties.java
@@ -13,4 +13,5 @@ public class SomniaBaseConfigProperties {
     private String basePackage = null;
     @Builder.Default
     private String mongoKeyIndexName = "s_key_index";
+    private String mongoValueHashIndexName = "s_value_hash_index";
 }

--- a/src/main/java/io/ep2p/somnia/config/properties/SomniaKademliaRepublishSettingsProperties.java
+++ b/src/main/java/io/ep2p/somnia/config/properties/SomniaKademliaRepublishSettingsProperties.java
@@ -1,0 +1,12 @@
+package io.ep2p.somnia.config.properties;
+
+import io.ep2p.kademlia.NodeSettings;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "somnia.config.kademlia.republish")
+@Getter
+@Setter
+public class SomniaKademliaRepublishSettingsProperties extends NodeSettings.RepublishSettings {
+}

--- a/src/main/java/io/ep2p/somnia/config/properties/SomniaKademliaSettingsProperties.java
+++ b/src/main/java/io/ep2p/somnia/config/properties/SomniaKademliaSettingsProperties.java
@@ -1,6 +1,5 @@
 package io.ep2p.somnia.config.properties;
 
-import io.ep2p.kademlia.NodeSettings;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -19,6 +18,4 @@ public class SomniaKademliaSettingsProperties {
     private int findNodeSize = 20;
     private int joinBucketQueries = 1;
     private int maximumLastSeenAgeToConsiderAlive = 20;
-    private boolean enabledRepublishing = false;
-    private NodeSettings.RepublishSettings republishSettings = new NodeSettings.RepublishSettings();
 }

--- a/src/main/java/io/ep2p/somnia/config/properties/SomniaKademliaSettingsProperties.java
+++ b/src/main/java/io/ep2p/somnia/config/properties/SomniaKademliaSettingsProperties.java
@@ -18,4 +18,5 @@ public class SomniaKademliaSettingsProperties {
     private int findNodeSize = 20;
     private int joinBucketQueries = 1;
     private int maximumLastSeenAgeToConsiderAlive = 20;
+    private boolean enabledRepublishing = false;
 }

--- a/src/main/java/io/ep2p/somnia/decentralized/SomniaNodeConnectionApi.java
+++ b/src/main/java/io/ep2p/somnia/decentralized/SomniaNodeConnectionApi.java
@@ -1,0 +1,14 @@
+package io.ep2p.somnia.decentralized;
+
+import io.ep2p.kademlia.connection.NodeConnectionApi;
+import io.ep2p.kademlia.node.Node;
+import io.ep2p.somnia.model.SomniaKey;
+import io.ep2p.somnia.model.SomniaValue;
+
+import java.math.BigInteger;
+import java.util.List;
+
+public interface SomniaNodeConnectionApi extends NodeConnectionApi<BigInteger, SomniaConnectionInfo> {
+    List<SomniaValue> readForKey(Node<BigInteger, SomniaConnectionInfo> caller, Node<BigInteger, SomniaConnectionInfo> node, SomniaKey somniaKey, int page, int limit);
+    boolean deleteForKey(Node<BigInteger, SomniaConnectionInfo> caller, Node<BigInteger, SomniaConnectionInfo> node, SomniaKey somniaKey);
+}

--- a/src/main/java/io/ep2p/somnia/model/SomniaEntity.java
+++ b/src/main/java/io/ep2p/somnia/model/SomniaEntity.java
@@ -22,4 +22,5 @@ public abstract class SomniaEntity<D extends Serializable> implements GenericObj
     private D data;
     private String key;
     private Date creationDate;
+    private Long valueHash;
 }

--- a/src/main/java/io/ep2p/somnia/model/SomniaKey.java
+++ b/src/main/java/io/ep2p/somnia/model/SomniaKey.java
@@ -21,6 +21,7 @@ public class SomniaKey implements Serializable {
     private int distributions = 0;
     @Builder.Default
     private Meta meta = new Meta();
+    private boolean republish = false;
 
     public synchronized void incrementDistribution(){
         this.distributions++;
@@ -32,6 +33,7 @@ public class SomniaKey implements Serializable {
                 .key(this.getKey())
                 .name(this.getName())
                 .hash(this.getHash())
+                .republish(this.isRepublish())
                 .hitNode(this.getHitNode())
                 .meta(this.getMeta().makeClone())
                 .build();
@@ -69,7 +71,7 @@ public class SomniaKey implements Serializable {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         SomniaKey somniaKey = (SomniaKey) o;
-        return Objects.equals(getKey(), somniaKey.getKey());
+        return key.equals(somniaKey.key) && name.equals(somniaKey.name);
     }
 
     @Override

--- a/src/main/java/io/ep2p/somnia/service/DefaultRedistributionTaskHandler.java
+++ b/src/main/java/io/ep2p/somnia/service/DefaultRedistributionTaskHandler.java
@@ -1,36 +1,145 @@
 package io.ep2p.somnia.service;
 
-import io.ep2p.kademlia.node.KademliaRepository;
 import io.ep2p.kademlia.node.Node;
 import io.ep2p.somnia.decentralized.SomniaConnectionInfo;
+import io.ep2p.somnia.decentralized.SomniaKademliaSyncRepositoryNode;
+import io.ep2p.somnia.decentralized.SomniaNodeConnectionApi;
 import io.ep2p.somnia.model.SomniaKey;
 import io.ep2p.somnia.model.SomniaValue;
+import lombok.Builder;
+import lombok.Data;
 
+import javax.annotation.PreDestroy;
 import java.math.BigInteger;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 
 public class DefaultRedistributionTaskHandler implements RedistributionTaskHandler {
-    private KademliaRepository<SomniaKey, SomniaValue> kademliaRepository;
+    private SomniaKademliaSyncRepositoryNode node;
+    private ScheduledExecutorService scheduledExecutorService = null;
+    private final Lock lock = new ReentrantLock();
+    private List<Task> tasks = new CopyOnWriteArrayList<>();
 
     @Override
-    public synchronized void init(KademliaRepository<SomniaKey, SomniaValue> kademliaRepository) {
-        assert kademliaRepository != null;
-        if (this.kademliaRepository == null){
-            this.kademliaRepository = kademliaRepository;
+    public synchronized void init(SomniaKademliaSyncRepositoryNode selfNode) {
+        assert selfNode != null;
+        if (this.node == null){
+            this.node = selfNode;
             this.start();
         }
     }
 
     @Override
-    public void addTask(SomniaKey somniaKey, Node<BigInteger, SomniaConnectionInfo> publisher) {
-
+    public synchronized void addTask(SomniaKey somniaKey, Node<BigInteger, SomniaConnectionInfo> publisher) {
+        Task task = Task.builder().somniaKey(somniaKey).publisher(publisher).build();
+        if (!this.tasks.contains(task)){
+            this.tasks.add(task);
+        }
     }
 
     private void start(){
-
+        this.scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
+        this.scheduledExecutorService.scheduleAtFixedRate(
+                this,
+                0,
+                10,
+                TimeUnit.MINUTES);
     }
 
     @Override
     public void run() {
+        if(this.lock.tryLock()){
+            try {
+                this.processTasks();
+            } finally {
+                this.lock.unlock();
+            }
+        }
+    }
 
+    /**
+     *  Looping through tasks and process each one
+     *  If an exception raise during the process we increase the failure flag on the task
+     *  If a task has failure > 0 we reduce the failure but ignore it and move to next tasks
+     *  This helps us prioritize cleaner tasks and not get stuck on them if they keep failing
+     */
+    private void processTasks() {
+        for (Task task : this.tasks) {
+            try {
+                if (task.getFailures() > 0){
+                    task.setFailures(task.getFailures() - 1);
+                    continue;
+                }
+                this.processTask(task);
+            }catch (Exception e){
+                task.setFailures(task.getFailures() + 1);
+            }
+        }
+    }
+
+    /**
+     *  To process a task, we send paginated requests to the publisher of the key and ask them for the data
+     *  Publisher validates that our node ID is closer to the key than them and starts to send us the result
+     *  We persist the result of each request till there are no results in the request
+     *  If an exception gets thrown in the process task remains in the queue
+     *  When all of the results are moved to our server we tell the publisher to remove their data
+     *  If the call for removing the data is successful we would delete the task from queue
+     */
+    private void processTask(Task task) {
+        int page = 1;
+        int size = 20;
+
+        if (this.node.getNodeConnectionApi() instanceof SomniaNodeConnectionApi){
+
+            List<SomniaValue> somniaValues = null;
+            while ((somniaValues = ((SomniaNodeConnectionApi) this.node.getNodeConnectionApi()).readForKey(
+                    this.node,
+                    task.getPublisher(),
+                    task.getSomniaKey(),
+                    page,
+                    size
+            )).size() > 0){
+                somniaValues.forEach(somniaValue -> {
+                    this.node.getKademliaRepository().store(task.getSomniaKey(), somniaValue);
+                });
+                page += 1;
+            }
+
+            if (((SomniaNodeConnectionApi) this.node.getNodeConnectionApi()).deleteForKey(this.node, task.getPublisher(), task.getSomniaKey())) {
+                this.tasks.remove(task);
+            }
+        }
+    }
+
+    @Data
+    @Builder
+    private static class Task {
+        private SomniaKey somniaKey;
+        private Node<BigInteger, SomniaConnectionInfo> publisher;
+        private int failures = 0;
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            Task task = (Task) o;
+            return Objects.equals(somniaKey, task.somniaKey);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(somniaKey);
+        }
+    }
+
+    @PreDestroy
+    public void destroy(){
+        this.scheduledExecutorService.shutdownNow();
     }
 }

--- a/src/main/java/io/ep2p/somnia/service/DefaultRedistributionTaskHandler.java
+++ b/src/main/java/io/ep2p/somnia/service/DefaultRedistributionTaskHandler.java
@@ -1,0 +1,36 @@
+package io.ep2p.somnia.service;
+
+import io.ep2p.kademlia.node.KademliaRepository;
+import io.ep2p.kademlia.node.Node;
+import io.ep2p.somnia.decentralized.SomniaConnectionInfo;
+import io.ep2p.somnia.model.SomniaKey;
+import io.ep2p.somnia.model.SomniaValue;
+
+import java.math.BigInteger;
+
+public class DefaultRedistributionTaskHandler implements RedistributionTaskHandler {
+    private KademliaRepository<SomniaKey, SomniaValue> kademliaRepository;
+
+    @Override
+    public synchronized void init(KademliaRepository<SomniaKey, SomniaValue> kademliaRepository) {
+        assert kademliaRepository != null;
+        if (this.kademliaRepository == null){
+            this.kademliaRepository = kademliaRepository;
+            this.start();
+        }
+    }
+
+    @Override
+    public void addTask(SomniaKey somniaKey, Node<BigInteger, SomniaConnectionInfo> publisher) {
+
+    }
+
+    private void start(){
+
+    }
+
+    @Override
+    public void run() {
+
+    }
+}

--- a/src/main/java/io/ep2p/somnia/service/EntityManagerRegisterer.java
+++ b/src/main/java/io/ep2p/somnia/service/EntityManagerRegisterer.java
@@ -97,12 +97,15 @@ public class EntityManagerRegisterer {
         if (somniaDocument.inMemory())
             return;
         log.info("Processing key indexing for " + aClass);
-        Index index = new Index("key", Sort.Direction.ASC).named(somniaBaseConfigProperties.getMongoKeyIndexName());
+        Index keyIndex = new Index("key", Sort.Direction.ASC).named(somniaBaseConfigProperties.getMongoKeyIndexName());
         if (somniaDocument.uniqueKey()) {
-            this.mongoTemplate.indexOps(aClass).ensureIndex(index.unique());
+            this.mongoTemplate.indexOps(aClass).ensureIndex(keyIndex.unique());
         }else {
-            this.mongoTemplate.indexOps(aClass).ensureIndex(index);
+            this.mongoTemplate.indexOps(aClass).ensureIndex(keyIndex);
         }
+
+        Index valueHashIndex = new Index("valueHash", Sort.Direction.ASC).named(somniaBaseConfigProperties.getMongoValueHashIndexName()).sparse();
+        this.mongoTemplate.indexOps(aClass).ensureIndex(valueHashIndex.unique());
 
     }
 }

--- a/src/main/java/io/ep2p/somnia/service/HashGenerator.java
+++ b/src/main/java/io/ep2p/somnia/service/HashGenerator.java
@@ -2,14 +2,24 @@ package io.ep2p.somnia.service;
 
 import java.io.Serializable;
 import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+
+import static com.google.common.hash.Hashing.sha256;
 
 public interface HashGenerator {
     <E extends Serializable> BigInteger hash(BigInteger id, E obj);
+    long hashSomniaValueData(String json);
 
     class DefaultHashGenerator implements HashGenerator {
         @Override
         public <E extends Serializable> BigInteger hash(BigInteger id, E obj) {
             return id;
+        }
+
+        @Override
+        public long hashSomniaValueData(String json) {
+            //noinspection UnstableApiUsage
+            return sha256().hashString(json, StandardCharsets.UTF_8).asLong();
         }
     }
 }

--- a/src/main/java/io/ep2p/somnia/service/RedistributionTaskHandler.java
+++ b/src/main/java/io/ep2p/somnia/service/RedistributionTaskHandler.java
@@ -1,0 +1,14 @@
+package io.ep2p.somnia.service;
+
+import io.ep2p.kademlia.node.KademliaRepository;
+import io.ep2p.kademlia.node.Node;
+import io.ep2p.somnia.decentralized.SomniaConnectionInfo;
+import io.ep2p.somnia.model.SomniaKey;
+import io.ep2p.somnia.model.SomniaValue;
+
+import java.math.BigInteger;
+
+public interface RedistributionTaskHandler extends Runnable {
+    void init(KademliaRepository<SomniaKey, SomniaValue> kademliaRepository);
+    void addTask(SomniaKey somniaKey, Node<BigInteger, SomniaConnectionInfo> publisher);
+}

--- a/src/main/java/io/ep2p/somnia/service/RedistributionTaskHandler.java
+++ b/src/main/java/io/ep2p/somnia/service/RedistributionTaskHandler.java
@@ -1,14 +1,13 @@
 package io.ep2p.somnia.service;
 
-import io.ep2p.kademlia.node.KademliaRepository;
 import io.ep2p.kademlia.node.Node;
 import io.ep2p.somnia.decentralized.SomniaConnectionInfo;
+import io.ep2p.somnia.decentralized.SomniaKademliaSyncRepositoryNode;
 import io.ep2p.somnia.model.SomniaKey;
-import io.ep2p.somnia.model.SomniaValue;
 
 import java.math.BigInteger;
 
 public interface RedistributionTaskHandler extends Runnable {
-    void init(KademliaRepository<SomniaKey, SomniaValue> kademliaRepository);
+    void init(SomniaKademliaSyncRepositoryNode selfNode);
     void addTask(SomniaKey somniaKey, Node<BigInteger, SomniaConnectionInfo> publisher);
 }

--- a/src/main/java/io/ep2p/somnia/service/SomniaRepublishStrategy.java
+++ b/src/main/java/io/ep2p/somnia/service/SomniaRepublishStrategy.java
@@ -1,0 +1,137 @@
+package io.ep2p.somnia.service;
+
+import io.ep2p.kademlia.NodeSettings;
+import io.ep2p.kademlia.model.FindNodeAnswer;
+import io.ep2p.kademlia.node.KademliaRepositoryNode;
+import io.ep2p.kademlia.node.Node;
+import io.ep2p.kademlia.node.TimestampAwareKademliaRepository;
+import io.ep2p.kademlia.node.external.ExternalNode;
+import io.ep2p.kademlia.service.RepublishStrategy;
+import io.ep2p.somnia.decentralized.SomniaConnectionInfo;
+import io.ep2p.somnia.model.SomniaKey;
+import io.ep2p.somnia.model.SomniaValue;
+import lombok.extern.slf4j.Slf4j;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+@Slf4j
+public class SomniaRepublishStrategy implements RepublishStrategy<BigInteger, SomniaConnectionInfo, SomniaKey, SomniaValue>, Runnable {
+    private KademliaRepositoryNode<BigInteger, SomniaConnectionInfo, SomniaKey, SomniaValue>  kademliaRepositoryNode;
+    private NodeSettings.RepublishSettings republishSettings;
+    private TimestampAwareKademliaRepository<SomniaKey, SomniaValue> timestampAwareKademliaRepository;
+    private ScheduledExecutorService scheduledExecutorService = null;
+    private volatile boolean isRunning = false;
+    private final Lock lock = new ReentrantLock();
+
+    @Override
+    public void configure(KademliaRepositoryNode<BigInteger, SomniaConnectionInfo, SomniaKey, SomniaValue> kademliaRepositoryNode, NodeSettings.RepublishSettings republishSettings, TimestampAwareKademliaRepository<SomniaKey, SomniaValue> timestampAwareKademliaRepository) {
+        this.republishSettings = republishSettings;
+        this.kademliaRepositoryNode = kademliaRepositoryNode;
+        this.timestampAwareKademliaRepository = timestampAwareKademliaRepository;
+        try {
+            this.init();
+        } catch (InterruptedException e) {
+            log.error("Failed to init DefaultRepublishStrategy", e);
+        }
+    }
+
+    public synchronized void init() throws InterruptedException {
+        if (this.scheduledExecutorService != null){
+            this.scheduledExecutorService.shutdown();
+            if(this.scheduledExecutorService.awaitTermination(1, TimeUnit.MINUTES)){
+                this.scheduledExecutorService.shutdownNow();
+            }
+            this.scheduledExecutorService = null;
+        }
+        this.scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
+        this.isRunning = false;
+    }
+
+    @Override
+    public synchronized void start() {
+        if (this.isRunning){
+            return;
+        }
+
+        this.scheduledExecutorService.scheduleAtFixedRate(
+                this,
+                0,
+                this.republishSettings.getRepublishIntervalValue(),
+                this.republishSettings.getRepublishIntervalUnit());
+        this.isRunning = true;
+    }
+
+    @Override
+    public void stop() {
+        this.scheduledExecutorService.shutdownNow();
+    }
+
+    @Override
+    public void run() {
+        boolean l = this.lock.tryLock();
+        if (l){
+            try {
+                Map<SomniaKey, SomniaValue> result = null;
+                int page = 1;
+                while ((
+                        result = this.timestampAwareKademliaRepository.getDataOlderThan(
+                                this.republishSettings.getRepublishQueryTimeValue(),
+                                this.republishSettings.getRepublishQueryUnit(),
+                                page,
+                                this.republishSettings.getRepublishQuerySizePerPage()
+                        )
+                ).size() > 0){
+                    page++;
+                    result.forEach(this::handleKeyRepublish);
+                    if (result.size() < this.republishSettings.getRepublishQuerySizePerPage()){
+                        break;
+                    }
+                }
+            }catch (Exception e){
+                log.error("Caught error while running republish strategy", e);
+            }finally {
+                this.lock.unlock();
+            }
+        }
+    }
+
+    public void handleKeyRepublish(SomniaKey key, SomniaValue value){
+        // ignoring passed value since strategy is just to inform the closer node to come read data from this node
+
+        // setting republish = true on the key for same reason
+        key.setRepublish(true);
+
+        for(Node<BigInteger, SomniaConnectionInfo> node : getNodesToPublishTo(key)){
+            this.kademliaRepositoryNode.getNodeConnectionApi().storeAsync(
+                    this.kademliaRepositoryNode, this.kademliaRepositoryNode, node, key, new SomniaValue()
+            );
+        }
+    }
+
+    public List<Node<BigInteger, SomniaConnectionInfo>> getNodesToPublishTo(SomniaKey key){
+        List<Node<BigInteger, SomniaConnectionInfo>> results = new ArrayList<>();
+
+        // Add closest node first
+        FindNodeAnswer<BigInteger, SomniaConnectionInfo> findNodeAnswer = this.kademliaRepositoryNode.getRoutingTable().findClosest(
+                this.kademliaRepositoryNode.getKeyHashGenerator().generate(key)
+        );
+
+        for (ExternalNode<BigInteger, SomniaConnectionInfo> node : findNodeAnswer.getNodes()) {
+            if (node.getId().equals(this.kademliaRepositoryNode.getId())){
+                continue;
+            }
+            results.add(node);
+            break;
+        }
+
+        return results;
+    }
+}

--- a/src/test/java/io/ep2p/somnia/DistributionTest.java
+++ b/src/test/java/io/ep2p/somnia/DistributionTest.java
@@ -12,6 +12,7 @@ import io.ep2p.somnia.decentralized.*;
 import io.ep2p.somnia.model.SomniaKey;
 import io.ep2p.somnia.model.SomniaValue;
 import io.ep2p.somnia.spring.configuration.LocalNodeConnectionApi;
+import io.ep2p.somnia.spring.mock.EmptyDistributionTaskHandler;
 import io.ep2p.somnia.spring.mock.SampleData;
 import io.ep2p.somnia.spring.mock.SampleSomniaEntity3;
 import io.ep2p.somnia.storage.DefaultInMemoryStorage;
@@ -47,7 +48,7 @@ public class DistributionTest {
         SomniaKademliaSyncRepositoryNode previousNode = null;
         for(int i = 0; i < this.nodeSize; i++){
             SomniaKademliaRepository somniaKademliaRepository = new SomniaKademliaRepository(somniaEntityManager, new DefaultInMemoryStorage(objectMapper), new DefaultInMemoryStorage(objectMapper));
-            SomniaKademliaSyncRepositoryNode node = new SomniaKademliaSyncRepositoryNode(BigInteger.valueOf(i), localNodeConnectionApi, new SomniaConnectionInfo(), NodeSettings.Default.build(), somniaKademliaRepository, somniaEntityManager, somniaStorageConfig);
+            SomniaKademliaSyncRepositoryNode node = new SomniaKademliaSyncRepositoryNode(BigInteger.valueOf(i), localNodeConnectionApi, new SomniaConnectionInfo(), NodeSettings.Default.build(), somniaKademliaRepository, somniaEntityManager, somniaStorageConfig, new EmptyDistributionTaskHandler());
             node.start();
             localNodeConnectionApi.registerNode(node);
             if (previousNode != null)

--- a/src/test/java/io/ep2p/somnia/MultiNodeTest.java
+++ b/src/test/java/io/ep2p/somnia/MultiNodeTest.java
@@ -8,11 +8,11 @@ import io.ep2p.kademlia.exception.BootstrapException;
 import io.ep2p.kademlia.exception.GetException;
 import io.ep2p.kademlia.exception.StoreException;
 import io.ep2p.kademlia.model.GetAnswer;
-import io.ep2p.kademlia.table.BigIntegerRoutingTable;
 import io.ep2p.somnia.decentralized.*;
 import io.ep2p.somnia.model.SomniaKey;
 import io.ep2p.somnia.model.SomniaValue;
 import io.ep2p.somnia.spring.configuration.LocalNodeConnectionApi;
+import io.ep2p.somnia.spring.mock.EmptyDistributionTaskHandler;
 import io.ep2p.somnia.spring.mock.SampleData;
 import io.ep2p.somnia.spring.mock.SampleSomniaEntity;
 import io.ep2p.somnia.spring.mock.SampleSomniaEntity2;
@@ -44,8 +44,8 @@ public class MultiNodeTest {
         SomniaKademliaRepository somniaKademliaRepository2 = new SomniaKademliaRepository(somniaEntityManager, new DefaultInMemoryStorage(objectMapper), new DefaultInMemoryStorage(objectMapper));
 
 
-        this.node1 = new SomniaKademliaSyncRepositoryNode(node1Id, localNodeConnectionApi, new SomniaConnectionInfo(), NodeSettings.Default.build(), somniaKademliaRepository1, somniaEntityManager);
-        this.node2 = new SomniaKademliaSyncRepositoryNode(node2Id, localNodeConnectionApi, new SomniaConnectionInfo(), NodeSettings.Default.build(), somniaKademliaRepository2, somniaEntityManager);
+        this.node1 = new SomniaKademliaSyncRepositoryNode(node1Id, localNodeConnectionApi, new SomniaConnectionInfo(), NodeSettings.Default.build(), somniaKademliaRepository1, somniaEntityManager, new EmptyDistributionTaskHandler());
+        this.node2 = new SomniaKademliaSyncRepositoryNode(node2Id, localNodeConnectionApi, new SomniaConnectionInfo(), NodeSettings.Default.build(), somniaKademliaRepository2, somniaEntityManager, new EmptyDistributionTaskHandler());
         this.node1.start();
         this.node2.start();
         localNodeConnectionApi.registerNode(node1);

--- a/src/test/java/io/ep2p/somnia/spring/MongoStorageTest.java
+++ b/src/test/java/io/ep2p/somnia/spring/MongoStorageTest.java
@@ -10,6 +10,7 @@ import io.ep2p.somnia.decentralized.SomniaConnectionInfo;
 import io.ep2p.somnia.decentralized.SomniaKademliaSyncRepositoryNode;
 import io.ep2p.somnia.model.SomniaKey;
 import io.ep2p.somnia.model.SomniaValue;
+import io.ep2p.somnia.service.HashGenerator;
 import io.ep2p.somnia.spring.configuration.LocalNodeConnectionApi;
 import io.ep2p.somnia.spring.configuration.SomniaTestConfiguration;
 import io.ep2p.somnia.spring.mock.SampleData;
@@ -52,7 +53,7 @@ public class MongoStorageTest {
             mongoTemplate.remove(new Query(), collectionName);
         });
         ((LocalNodeConnectionApi<BigInteger>) nodeConnectionApi).registerNode(somniaKademliaSyncRepositoryNode);
-        this.mongoStorage = new MongoStorage(mongoTemplate, objectMapper);
+        this.mongoStorage = new MongoStorage(mongoTemplate, objectMapper, new HashGenerator.DefaultHashGenerator());
         this.objectMapper = objectMapper;
     }
 

--- a/src/test/java/io/ep2p/somnia/spring/mock/EmptyDistributionTaskHandler.java
+++ b/src/test/java/io/ep2p/somnia/spring/mock/EmptyDistributionTaskHandler.java
@@ -1,17 +1,16 @@
 package io.ep2p.somnia.spring.mock;
 
-import io.ep2p.kademlia.node.KademliaRepository;
 import io.ep2p.kademlia.node.Node;
 import io.ep2p.somnia.decentralized.SomniaConnectionInfo;
+import io.ep2p.somnia.decentralized.SomniaKademliaSyncRepositoryNode;
 import io.ep2p.somnia.model.SomniaKey;
-import io.ep2p.somnia.model.SomniaValue;
 import io.ep2p.somnia.service.RedistributionTaskHandler;
 
 import java.math.BigInteger;
 
 public class EmptyDistributionTaskHandler implements RedistributionTaskHandler {
     @Override
-    public void init(KademliaRepository<SomniaKey, SomniaValue> kademliaRepository) {
+    public void init(SomniaKademliaSyncRepositoryNode selfNode) {
 
     }
 

--- a/src/test/java/io/ep2p/somnia/spring/mock/EmptyDistributionTaskHandler.java
+++ b/src/test/java/io/ep2p/somnia/spring/mock/EmptyDistributionTaskHandler.java
@@ -1,0 +1,27 @@
+package io.ep2p.somnia.spring.mock;
+
+import io.ep2p.kademlia.node.KademliaRepository;
+import io.ep2p.kademlia.node.Node;
+import io.ep2p.somnia.decentralized.SomniaConnectionInfo;
+import io.ep2p.somnia.model.SomniaKey;
+import io.ep2p.somnia.model.SomniaValue;
+import io.ep2p.somnia.service.RedistributionTaskHandler;
+
+import java.math.BigInteger;
+
+public class EmptyDistributionTaskHandler implements RedistributionTaskHandler {
+    @Override
+    public void init(KademliaRepository<SomniaKey, SomniaValue> kademliaRepository) {
+
+    }
+
+    @Override
+    public void addTask(SomniaKey somniaKey, Node<BigInteger, SomniaConnectionInfo> publisher) {
+
+    }
+
+    @Override
+    public void run() {
+
+    }
+}


### PR DESCRIPTION
This PR contains code and logic for Somnia to publish keys of type `HIT` to closer nodes if any exist.
How it works is that using kademlia-api's `RepublishStrategy` the Somnia node publishes keys and only keys (not their values).
If a closer node catches the key it will start to send requests to the publisher and read all of the values and store in its DB.
When the process is done the new node will tell the older node to delete all of the respective key values.